### PR TITLE
Accounts: don't create battlenet accounts when exp <= cataclysm

### DIFF
--- a/application/models/M_data.php
+++ b/application/models/M_data.php
@@ -123,7 +123,7 @@ class M_data extends CI_Model {
         $passwordBn = $this->encryptBattlenet($email, $password);
         $tag = rand(1111, 9999);
 
-        if ($this->m_general->getExpansionAction($this->config->item('expansion_id')) == 1)
+        if ($this->m_general->getExpansionAction($this->config->item('expansion_id')) <= 3)
         {
             $this->auth = $this->load->database('auth', TRUE);
             


### PR DESCRIPTION
Do not create battle net accounts for expansions up to cataclysm since the 3.3.5 nor the 4.3.4 branch of trinity and mangos support battle net